### PR TITLE
Clear abort event listener for all xhr completion states.

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -470,7 +470,6 @@
 
       xhr.onabort = function() {
         reject(new DOMException('Aborted', 'AbortError'))
-        request.signal.removeEventListener('abort', abortXhr)
       }
 
       xhr.open(request.method, request.url, true)
@@ -491,6 +490,13 @@
 
       if (request.signal) {
         request.signal.addEventListener('abort', abortXhr)
+
+        xhr.onreadystatechange = function() {
+          // DONE (success or failure)
+          if (xhr.readyState === 4) {
+            request.signal.removeEventListener('abort', abortXhr)
+          }
+        }
       }
 
       xhr.send(typeof request._bodyInit === 'undefined' ? null : request._bodyInit)

--- a/test/test.js
+++ b/test/test.js
@@ -993,6 +993,34 @@ suite('fetch method', function() {
         assert.isUndefined(signal._handler)
       })
     })
+
+    test('does not leak memory', function() {
+      var signal = {
+        aborted: false,
+        addEventListener: function(name, fn) {
+          this._handler = fn
+        },
+        removeEventListener: function(name, fn) {
+          if (this._handler === fn) {
+            delete this._handler
+          }
+        }
+      }
+
+      // success
+      return fetch('/request', {
+        signal: signal
+      }).then(function() {
+        assert.isUndefined(signal._handler)
+      }).then(function () {
+        // failure
+        return fetch('/boom', {
+          signal: signal
+        }).catch(function() {
+          assert.isUndefined(signal._handler)
+        })
+      });
+    })
   })
 
   suite('response', function() {


### PR DESCRIPTION
Clear event listener whenever xhr is done (not just on abort). Signal may be hanging without never aborting.