### PR TITLE
Test signal reuse. Add AbortSignal polyfill.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,6 +20,7 @@
   "worker": true,
   "globals": {
     "JSON": false,
-    "URLSearchParams": false
+    "URLSearchParams": false,
+    "AbortSignal": false
   }
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -21,6 +21,7 @@
   "globals": {
     "JSON": false,
     "URLSearchParams": false,
+    "EventTarget": false,
     "AbortSignal": false
   }
 }

--- a/test/abortsignal-polyfill.js
+++ b/test/abortsignal-polyfill.js
@@ -9,28 +9,29 @@
   // Polyfill EventTarget if not available.
   self.EventTarget = self.EventTarget || (function () {
     function EventTarget () {
-      this._listeners = {}
+      this.listeners = {}
     }
-    EventTarget.prototype.addEventListener = function(name, fn) {
-      if (!(name in this._listeners)) {
-        this._listeners[name] = []
+    EventTarget.prototype.listeners = null;
+    EventTarget.prototype.addEventListener = function(type, callback) {
+      if (!(type in this.listeners)) {
+        this.listeners[type] = []
       }
-      this._listeners[name].push(fn)
+      this.listeners[type].push(callback)
     }
-    EventTarget.prototype.removeEventListener = function(name, fn) {
-      if (!(name in this._listeners)) {
+    EventTarget.prototype.removeEventListener = function(type, callback) {
+      if (!(type in this.listeners)) {
         return
       }
-      var stack = this._listeners[name]
-      for (var i = 0; i < stack.length; i++) {
-        if (stack[i] === fn){
+      var stack = this.listeners[type]
+      for (var i = 0, l = stack.length; i < l; i++) {
+        if (stack[i] === callback){
           stack.splice(i, 1)
           return
         }
       }
     }
     EventTarget.prototype.dispatchEvent = function(event) {
-      if (!(event.type in this._listeners)) {
+      if (!(event.type in this.listeners)) {
         return
       }
       function debounce (fn) {
@@ -38,10 +39,11 @@
           fn.call(this, event)
         }, 0)
       }
-      var stack = this._listeners[event.type]
-      for (var i = 0; i < stack.length; i++) {
+      var stack = this.listeners[event.type]
+      for (var i = 0, l = stack.length; i < l; i++) {
         debounce(stack[i])
       }
+      return !event.defaultPrevented
     }
 
     return EventTarget

--- a/test/abortsignal-polyfill.js
+++ b/test/abortsignal-polyfill.js
@@ -1,0 +1,68 @@
+// Simple AbortSignal polyfill used for testing.
+(function(self) {
+  'use strict';
+
+  if (self.AbortSignal) {
+    return
+  }
+
+  // Polyfill EventTarget if not available.
+  self.EventTarget = self.EventTarget || (function () {
+    function EventTarget () {
+      this._listeners = {}
+    }
+    EventTarget.prototype.addEventListener = function(name, fn) {
+      if (!(name in this._listeners)) {
+        this._listeners[name] = []
+      }
+      this._listeners[name].push(fn)
+    }
+    EventTarget.prototype.removeEventListener = function(name, fn) {
+      if (!(name in this._listeners)) {
+        return
+      }
+      var stack = this._listeners[name]
+      for (var i = 0; i < stack.length; i++) {
+        if (stack[i] === fn){
+          stack.splice(i, 1)
+          return
+        }
+      }
+    }
+    EventTarget.prototype.dispatchEvent = function(event) {
+      if (!(event.type in this._listeners)) {
+        return
+      }
+      function debounce (fn) {
+        setTimeout(function () {
+          fn.call(this, event)
+        }, 0)
+      }
+      var stack = this._listeners[event.type]
+      for (var i = 0; i < stack.length; i++) {
+        debounce(stack[i])
+      }
+    }
+
+    return EventTarget
+  })();
+
+  function AbortSignal () {
+    self.EventTarget.call(this)
+    this.aborted = false
+  }
+  AbortSignal.prototype = Object.create(self.EventTarget.prototype)
+  AbortSignal.prototype.constructor = AbortSignal
+
+  AbortSignal.prototype.dispatchEvent = function(event) {
+    if (event.type === 'abort'){
+      this.aborted = true
+      if (typeof this.onabort === 'function') {
+        this.onabort.call(this, event)
+      }
+    }
+    self.EventTarget.prototype.dispatchEvent.call(this, event)
+  }
+
+  self.AbortSignal = AbortSignal
+})(typeof self !== 'undefined' ? self : this);

--- a/test/abortsignal-polyfill.js
+++ b/test/abortsignal-polyfill.js
@@ -1,4 +1,53 @@
-// Simple AbortSignal polyfill used for testing.
+// EventTarget Polyfill
+(function(self) {
+  'use strict';
+
+  if (self.EventTarget) {
+    return
+  }
+
+  function EventTarget () {
+    this.listeners = {}
+  }
+  EventTarget.prototype.listeners = null;
+  EventTarget.prototype.addEventListener = function(type, callback) {
+    if (!(type in this.listeners)) {
+      this.listeners[type] = []
+    }
+    this.listeners[type].push(callback)
+  }
+  EventTarget.prototype.removeEventListener = function(type, callback) {
+    if (!(type in this.listeners)) {
+      return
+    }
+    var stack = this.listeners[type]
+    for (var i = 0, l = stack.length; i < l; i++) {
+      if (stack[i] === callback){
+        stack.splice(i, 1)
+        return
+      }
+    }
+  }
+  EventTarget.prototype.dispatchEvent = function(event) {
+    if (!(event.type in this.listeners)) {
+      return
+    }
+    function debounce (fn) {
+      setTimeout(function () {
+        fn.call(this, event)
+      }, 0)
+    }
+    var stack = this.listeners[event.type]
+    for (var i = 0, l = stack.length; i < l; i++) {
+      debounce(stack[i])
+    }
+    return !event.defaultPrevented
+  }
+
+  self.EventTarget = EventTarget
+})(typeof self !== 'undefined' ? self : this);
+  
+// AbortSignal polyfill
 (function(self) {
   'use strict';
 
@@ -6,54 +55,11 @@
     return
   }
 
-  // Polyfill EventTarget if not available.
-  self.EventTarget = self.EventTarget || (function () {
-    function EventTarget () {
-      this.listeners = {}
-    }
-    EventTarget.prototype.listeners = null;
-    EventTarget.prototype.addEventListener = function(type, callback) {
-      if (!(type in this.listeners)) {
-        this.listeners[type] = []
-      }
-      this.listeners[type].push(callback)
-    }
-    EventTarget.prototype.removeEventListener = function(type, callback) {
-      if (!(type in this.listeners)) {
-        return
-      }
-      var stack = this.listeners[type]
-      for (var i = 0, l = stack.length; i < l; i++) {
-        if (stack[i] === callback){
-          stack.splice(i, 1)
-          return
-        }
-      }
-    }
-    EventTarget.prototype.dispatchEvent = function(event) {
-      if (!(event.type in this.listeners)) {
-        return
-      }
-      function debounce (fn) {
-        setTimeout(function () {
-          fn.call(this, event)
-        }, 0)
-      }
-      var stack = this.listeners[event.type]
-      for (var i = 0, l = stack.length; i < l; i++) {
-        debounce(stack[i])
-      }
-      return !event.defaultPrevented
-    }
-
-    return EventTarget
-  })();
-
   function AbortSignal () {
-    self.EventTarget.call(this)
+    EventTarget.call(this)
     this.aborted = false
   }
-  AbortSignal.prototype = Object.create(self.EventTarget.prototype)
+  AbortSignal.prototype = Object.create(EventTarget.prototype)
   AbortSignal.prototype.constructor = AbortSignal
 
   AbortSignal.prototype.dispatchEvent = function(event) {
@@ -63,7 +69,7 @@
         this.onabort.call(this, event)
       }
     }
-    self.EventTarget.prototype.dispatchEvent.call(this, event)
+    EventTarget.prototype.dispatchEvent.call(this, event)
   }
 
   self.AbortSignal = AbortSignal

--- a/test/test.html
+++ b/test/test.html
@@ -33,6 +33,7 @@
   </script>
 
   <script src="/node_modules/promise-polyfill/promise.js"></script>
+  <script src="/test/abortsignal-polyfill.js"></script>
   <script src="/test/test.js"></script>
   <script src="/fetch.js"></script>
 

--- a/test/test.js
+++ b/test/test.js
@@ -1014,13 +1014,13 @@ suite('fetch method', function() {
       return fetch('/request', {
         signal: signal
       }).then(function() {
-        assert.deepEqual(signal._listeners['abort'], [])
+        assert.deepEqual(signal.listeners['abort'], [])
       }).then(function () {
         // failure
         return fetch('/boom', {
           signal: signal
         }).catch(function() {
-          assert.deepEqual(signal._listeners['abort'], [])
+          assert.deepEqual(signal.listeners['abort'], [])
         })
       }).then(function () {
         // aborted
@@ -1031,7 +1031,7 @@ suite('fetch method', function() {
         return fetch('/slow', {
           signal: signal
         }).catch(function() {
-          assert.deepEqual(signal._listeners['abort'], [])
+          assert.deepEqual(signal.listeners['abort'], [])
         })
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -954,8 +954,11 @@ suite('fetch method', function() {
 
   suite('aborting', function() {
     test('initially aborted signal', function() {
+      const signal = new AbortSignal()
+      signal.aborted = true
+
       return fetch('/request', {
-        signal: {aborted: true}
+        signal: signal
       }).then(function() {
         assert.ok(false)
       }, function(error) {
@@ -964,24 +967,10 @@ suite('fetch method', function() {
     })
 
     test('mid-request', function() {
-      var signal = {
-        aborted: false,
-        addEventListener: function(name, fn) {
-          assert.equal(name, 'abort')
-          this._handler = fn
-        },
-        removeEventListener: function(name, fn) {
-          assert.equal(name, 'abort')
-          if (this._handler === fn) {
-            delete this._handler
-          }
-        }
-      }
+      const signal = new AbortSignal()
 
       setTimeout(function() {
-        if (signal._handler) {
-          signal._handler()
-        }
+        signal.dispatchEvent({ type: 'abort' })
       }, 30)
 
       return fetch('/slow', {
@@ -990,36 +979,61 @@ suite('fetch method', function() {
         assert.ok(false)
       }, function(error) {
         assert.equal(error.name, 'AbortError')
-        assert.isUndefined(signal._handler)
       })
     })
 
+    test('abort multiple with same signal', function() {
+      const signal = new AbortSignal()
+
+      setTimeout(function() {
+        signal.dispatchEvent({ type: 'abort' })
+      }, 30)
+
+      return Promise.all([
+        fetch('/slow', {
+          signal: signal
+        }).then(function() {
+          assert.ok(false)
+        }, function(error) {
+          assert.equal(error.name, 'AbortError')
+        }),
+        fetch('/slow', {
+          signal: signal
+        }).then(function() {
+          assert.ok(false)
+        }, function(error) {
+          assert.equal(error.name, 'AbortError')
+        })
+      ])
+    })
+
     test('does not leak memory', function() {
-      var signal = {
-        aborted: false,
-        addEventListener: function(name, fn) {
-          this._handler = fn
-        },
-        removeEventListener: function(name, fn) {
-          if (this._handler === fn) {
-            delete this._handler
-          }
-        }
-      }
+      const signal = new AbortSignal()
 
       // success
       return fetch('/request', {
         signal: signal
       }).then(function() {
-        assert.isUndefined(signal._handler)
+        assert.deepEqual(signal._listeners['abort'], [])
       }).then(function () {
         // failure
         return fetch('/boom', {
           signal: signal
         }).catch(function() {
-          assert.isUndefined(signal._handler)
+          assert.deepEqual(signal._listeners['abort'], [])
         })
-      });
+      }).then(function () {
+        // aborted
+        setTimeout(function() {
+          signal.dispatchEvent({ type: 'abort' })
+        }, 30)
+
+        return fetch('/slow', {
+          signal: signal
+        }).catch(function() {
+          assert.deepEqual(signal._listeners['abort'], [])
+        })
+      })
     })
   })
 

--- a/test/worker.js
+++ b/test/worker.js
@@ -5,6 +5,7 @@ mocha.setup('tdd')
 self.assert = chai.assert
 
 importScripts('/node_modules/promise-polyfill/promise.js')
+importScripts('/test/abortsignal-polyfill.js')
 importScripts('/test/test.js')
 importScripts('/fetch.js')
 


### PR DESCRIPTION
Added a test for reusing the same signal to cancel multiple fetch requests (e.g. https://developers.google.com/web/updates/2017/09/abortable-fetch#one_signal_many_fetches)

With that I noticed we needed a better polyfill to handle multiple event listeners, so I added an AbortSignal polyfill (with [`EventTarget`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget#Example)). It's on a separate file so it can be swapped with any other implementation. I'm keen on fixing https://github.com/mo/abortcontroller-polyfill/issues/11 and use that instead when ready.

(Sorry, I know I could've pushed to your branch directly, but had already a big chunk of WIP on mine)